### PR TITLE
support https

### DIFF
--- a/src/export.ml
+++ b/src/export.ml
@@ -129,9 +129,18 @@ let t () =
 
   let p = Export_env.local_port () |> int_of_string in
   let () = Logs.info (fun m -> m "serving on port %d" p) in
-  let app =
+
+  let cert = Export_env.cert_path ()
+  and key  = Export_env.key_path () in
+
+  let base_app =
     App.empty
     |> App.port p
+    |> (if cert != "" && key != "" then App.ssl ~cert ~key
+        else fun b -> b)
+  in
+  let app =
+    base_app
     |> middleware Macaroon.macaroon_verifier_mw
     |> export queue in
 

--- a/src/export_env.ml
+++ b/src/export_env.ml
@@ -24,3 +24,16 @@ let arbiter_token () =
   try Sys.getenv "ARBITER_TOKEN"
   with Not_found -> !arbiter_key
 
+
+let cert_path = ref ""
+let key_path  = ref ""
+
+
+let cert_path () =
+  try Sys.getenv "HTTPS_SERVER_CERT"
+  with Not_found -> !cert_path
+
+
+let key_path () =
+  try Sys.getenv "HTTPS_SERVER_PRIVATE_KEY"
+  with Not_found -> !key_path

--- a/src/export_env.mli
+++ b/src/export_env.mli
@@ -5,3 +5,7 @@ val local_port : unit -> string
 val arbiter_endp : unit -> string
 
 val arbiter_token : unit -> string
+
+val cert_path : unit -> string
+
+val key_path : unit -> string


### PR DESCRIPTION
I saw the environment variables used in store-blob are [HTTPS_CLIENT_CERT](https://github.com/me-box/databox-store-blob/blob/master/src/main.js#L24) and [HTTPS_CLIENT_PRIVATE_KEY](https://github.com/me-box/databox-store-blob/blob/master/src/main.js#L25), but wondering if it should be `*SERVER*` here.