### PR TITLE
 databox.type label is required

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,7 @@ RUN git clone https://github.com/sevenEng/databox-bridge.git \
   && ocaml pkg/pkg.ml test \
   && opam install databox-export-service
 
+LABEL databox.type="export-service"
+
 ENTRYPOINT ["opam", "config", "exec", "--"]
 CMD ["databox-export-service"]


### PR DESCRIPTION
This label is needed so that container manager knows to treat it as a databox container.