### PR TITLE
install tls support into conduit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM ocaml/opam:alpine
 RUN sudo apk add libsodium-dev libffi-dev
 
 RUN opam depext -y conf-m4.1
+RUN opam depext -y conf-gmp.1
 RUN opam pin add -n sodium https://github.com/dsheets/ocaml-sodium.git
 RUN opam pin add -n macaroons https://github.com/nojb/ocaml-macaroons.git
 RUN opam pin add -n depyt https://github.com/sevenEng/depyt.git#fix-opam

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN opam depext -y conf-gmp.1
 RUN opam pin add -n sodium https://github.com/dsheets/ocaml-sodium.git
 RUN opam pin add -n macaroons https://github.com/nojb/ocaml-macaroons.git
 RUN opam pin add -n depyt https://github.com/sevenEng/depyt.git#fix-opam
+RUN opam pin add -n opium https://github.com/sevenEng/opium.git#fix-ssl-option
 
 # tests use three ports
 # while the service will be on 8080

--- a/opam
+++ b/opam
@@ -17,6 +17,7 @@ depends: [
 
   "lwt"
   "fmt"
+  "tls"
   "opium"
   "cohttp"
   "sodium"

--- a/test/test.ml
+++ b/test/test.ml
@@ -720,8 +720,9 @@ let main () =
       try
         Lwt_main.run @@ TC.client ();
         Logs.info (fun m -> m "[client] OK!")
-      with _ ->
+      with exn ->
         Logs.err (fun m -> m "[client] ERROR!");
+        Logs.err (fun m -> m "[client] %s" (Printexc.to_string exn));
         exit 1 end
   | pid ->
       let wait () =


### PR DESCRIPTION
tried to fix #9 , but encountered a bug in a dependent library,
have to wait for [the fix patch](https://github.com/rgrinberg/opium/pull/66) to be merged