### PR TITLE
Get macaroon secret from arbiter lazily and update Dockerfier

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,27 +5,21 @@ RUN sudo apk add libsodium-dev libffi-dev
 RUN opam depext -y conf-m4.1
 RUN opam depext -y conf-gmp.1
 RUN opam depext -y conf-perl.1
+
 RUN opam pin add -n sodium https://github.com/dsheets/ocaml-sodium.git
 RUN opam pin add -n macaroons https://github.com/nojb/ocaml-macaroons.git
 RUN opam pin add -n depyt https://github.com/sevenEng/depyt.git#fix-opam
 RUN opam pin add -n opium https://github.com/sevenEng/opium.git#fix-ssl-option
 
-# tests use three ports
-# while the service will be on 8080
-EXPOSE 8080 8000 8888 8008
+WORKDIR /home/opam
 
-RUN git clone https://github.com/me-box/databox-export-service.git \
-  && cd databox-export-service \
-  && opam pin add -n databox-export-service . \
-  && opam install --deps-only databox-export-service
+ADD . databox-export-service
 
-RUN eval `opam config env` \
-  && cd databox-export-service \
-  && ocaml pkg/pkg.ml build --tests true \
-  && ocaml pkg/pkg.ml test \
-  && opam install databox-export-service
+RUN cd databox-export-service \
+ && opam pin add -y databox-export-service .
+
+EXPOSE 8080
 
 LABEL databox.type="export-service"
 
-ENTRYPOINT ["opam", "config", "exec", "--"]
 CMD ["databox-export-service"]

--- a/bin/service.ml
+++ b/bin/service.ml
@@ -1,4 +1,4 @@
 let () =
   Logs.set_reporter (Logs_fmt.reporter ());
-  Logs.(set_level (Some Info));
+  Logs.(set_level (Some Debug));
   Lwt_main.run @@ Export.t ()

--- a/src/export.ml
+++ b/src/export.ml
@@ -210,11 +210,10 @@ let t () =
     |> export_lp queue
   in
 
-  let export_queue =
+  let export_queue () =
     match App.run_command' app with
     | `Ok t -> t
     | _ -> assert false
   in
 
-  Macaroon.init () >>= fun () ->
-  Lwt.join [export_queue; worker_t queue; ]
+  Lwt.join [export_queue (); worker_t queue; ]

--- a/src/macaroon.ml
+++ b/src/macaroon.ml
@@ -36,7 +36,9 @@ let secret () =
     match !s with
     | None ->
         if cnt >= repeat then return @@ R.error_msg "Can't get macaroon secret"
-        else get_secret () >>= fun () -> aux @@ succ cnt
+        else Logs_lwt.debug (fun m -> m
+          "[macaroon] try to get macaroon secret %d/%d" cnt repeat)
+          >>= get_secret >>= fun () -> aux @@ succ cnt
     | Some s -> return @@ R.ok s
   in
   aux 1
@@ -153,6 +155,8 @@ let extract_destination body =
 
 let macaroon_verifier_mw =
   let filter = fun handler req ->
+    secret () >>= fun key ->
+
     let uri = Request.uri req in
     let meth = Request.meth req in
     let headers = Request.headers req in
@@ -162,8 +166,6 @@ let macaroon_verifier_mw =
     let dest = extract_destination b in
 
     let macaroon = extract_macaroon headers in
-    secret () >>= fun key ->
-
     let r = verify macaroon key uri meth dest in
 
     if R.is_error r then
@@ -174,7 +176,7 @@ let macaroon_verifier_mw =
         Format.flush_str_formatter ()
       in
       let info = Printf.sprintf "macaroon verification fails: %s" msg in
-      Logs_lwt.info (fun m -> m "%s" info) >>= fun () ->
+      Logs_lwt.info (fun m -> m "[macaroon] %s" info) >>= fun () ->
 
       let body = Cohttp_lwt_body.of_string info in
       let code = `Unauthorized in
@@ -182,13 +184,13 @@ let macaroon_verifier_mw =
 
     else match R.get_ok r with
     | true ->
-        Logs_lwt.info (fun m -> m "macaroon verification passes") >>= fun () ->
+        Logs_lwt.info (fun m -> m "[macaroon] macaroon verification passes") >>= fun () ->
         let b = Cohttp_lwt_body.of_string b in
         let req = Request.({req with body = b}) in
         handler req
     | false ->
         let info = "Invalid API key/token" in
-        Logs_lwt.info (fun m -> m "%s" info) >>= fun () ->
+        Logs_lwt.info (fun m -> m "[macaroon] %s" info) >>= fun () ->
 
         let body = Cohttp_lwt_body.of_string info in
         let code = `Unauthorized in

--- a/src/macaroon.mli
+++ b/src/macaroon.mli
@@ -1,2 +1,1 @@
-val init : unit -> unit Lwt.t
 val macaroon_verifier_mw : Opium_rock.Middleware.t

--- a/test/test.ml
+++ b/test/test.ml
@@ -422,7 +422,9 @@ module Test_client'' = struct
       in
       let next_ts () =
         match M.get_env "ext_resp" with
-        | None -> return_some step1
+        | None ->
+            Lwt_unix.sleep 0.5 >>= fun ()->
+            return_some step1
         | Some ext_resp ->
             let ext_resp = Ezjsonm.(
                 from_string ext_resp


### PR DESCRIPTION
- Lasy secret: give cm enough time to connect it to the right network, and won't ask for the macaroon secret until the very first export request comes in
- Dockerfile: no tests within autobuild, [error 0](https://hub.docker.com/r/seveneng/databox-export-service-fork/builds/bvtfsw5e7gqptz3bcnbejrl/), [success 0](https://hub.docker.com/r/seveneng/databox-export-service-fork/builds/btr9bvytekdtk8jbgj66rtk/), [error 1](https://hub.docker.com/r/seveneng/databox-export-service-fork/builds/bzyv6si3f2smzkpdv3rtcvf/), [success 1](https://hub.docker.com/r/seveneng/databox-export-service-fork/builds/br7eqvraeikhgt96xe5lxev/), these four successive builds are based on the same code, the last three were triggered manually, but they gave really different build logs *(success 1 has way too tests output than success 0)*, not sure what happened 