### PR TITLE
one app/driver one queue

### DIFF
--- a/src/export_env.ml
+++ b/src/export_env.ml
@@ -1,4 +1,4 @@
-let local_name = ref "databox-export-bridge"
+let local_name = ref "databox-export-service"
 let local_port = ref "8080"
 
 let arbiter_endpoint = ref "https://databox-arbiter:8080"

--- a/src/export_factory.ml
+++ b/src/export_factory.ml
@@ -1,0 +1,38 @@
+open Export_typ
+open Lwt.Infix
+
+module W = Export_worker
+
+type factory = {
+  w_tbl : (string, W.queue) Hashtbl.t;
+  push  : W.queue option -> unit;
+}
+
+
+let get_queue {w_tbl; push} ~id =
+  if Hashtbl.mem w_tbl id then Hashtbl.find w_tbl id
+  else begin
+    Logs.info (fun m -> m "new worker needed for client: %s" id);
+    let q = W.create_queue ~owner:id in
+    Hashtbl.replace w_tbl id q;
+    push (Some q);
+    q
+  end
+
+
+let init () =
+  let f, push = Lwt_stream.create () in
+  let s, _ = Lwt.wait () in
+  let rec factory workers () =
+    Lwt.choose [
+      Lwt_stream.get f;
+      Lwt.join workers >>= fun () -> Lwt.return_none] >>= function
+    | None ->
+        if Lwt_stream.is_closed f then
+          Logs_lwt.err (fun m -> m "new worker stream closed")
+        else begin
+          Logs_lwt.warn (fun m -> m "some worker failes") >>= fun () -> factory workers ()
+        end
+    | Some q -> factory (W.worker_t q :: workers) ()
+  in
+  factory [s], {w_tbl = Hashtbl.create 13; push}

--- a/src/export_factory.mli
+++ b/src/export_factory.mli
@@ -1,0 +1,5 @@
+type factory
+
+val get_queue : factory -> id:string -> Export_worker.queue
+
+val init : unit -> (unit -> unit Lwt.t) * factory

--- a/src/export_worker.mli
+++ b/src/export_worker.mli
@@ -2,7 +2,7 @@ type queue
 
 type id = Uuidm.t
 
-val get_queue : unit -> queue
+val create_queue : owner:string -> queue
 
 val new_request : Export_typ.request -> queue -> Export_typ.response
 

--- a/src/export_ws.ml
+++ b/src/export_ws.ml
@@ -165,7 +165,7 @@ let mode p =
 
 
 let ws ?secret ?port () =
-  let q = W.get_queue () in
+  let q = W.create_queue ~owner:"ws" in
   let port =
     match port with
     | None -> Export_env.local_port () |> int_of_string


### PR DESCRIPTION
- macaroon checker differentiates clients by `id` field
- [export_factory](../blob/factory/src/export_factory.ml#L12) links each unique `id` with a separate export queue together with a worker working on those requests

#### TODO:
- queues are added but never deleted _(timer, no new request, timeout, delete queue)_
- ws still operates on one queue
- tests for this
- _maybe some queue management: max queueing requests? etc_